### PR TITLE
add 4 space indentation rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,11 @@ module.exports = {
     'node_modules',
   ],
   opt_in_rules: [
-    'implicitly_unwrapped_optional',
     'file_name_no_space',
     'force_unwrapping',
     'function_default_parameter_at_end',
+    'implicitly_unwrapped_optional',
+    'indentation_width',
     'lower_acl_than_parent',
     'modifier_order',
     'overridden_super_call',


### PR DESCRIPTION
This will add a warning when linting about mismatched indentation, e.g.:

```
CAPBridge.swift:598:1: warning: Indentation Width Violation: Code should be unindented by multiples of one tab or multiples of 4 spaces. (indentation_width)
CAPBridge.swift:602:1: warning: Indentation Width Violation: Code should be indented using one tab or 4 spaces. (indentation_width)
```

This rule does not appear to have an autocorrect option, but we can use Xcode's "re-indent on paste" feature to fix the indentation of Capacitor swift files.