### PR TITLE
chore: Add Pods folder to excluded

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   excluded: [
     'node_modules',
+    'ios/Pods',
   ],
   opt_in_rules: [
     'implicitly_unwrapped_optional',


### PR DESCRIPTION
I was having problems with lint on network plugin because of Pods folder having Reachability code.
I think we should exclude Pods folder as the code there is not ours. 