### PR TITLE
docs: fix swiftlint command instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ Shared SwiftLint config used in Ionic and Capacitor projects.
 1. Add the following to `package.json`:
 
     ```
-    "swiftlint": "@ionic/swiftlint-config",
+    "swiftlint": "node-swiftlint",
     ```


### PR DESCRIPTION
I think the command is wrong, at least we are using `node-swiftlint`, not `@ionic/swiftlint-config`