### PR TITLE
fix!: adjust excluded paths for swiftlint >= 0.43.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 module.exports = {
   excluded: [
-    'node_modules',
-    'ios/Pods',
+    '${PWD}/node_modules',
+    '${PWD}/ios/Pods',
+    '${PWD}/example-app',
   ],
   opt_in_rules: [
     'implicitly_unwrapped_optional',


### PR DESCRIPTION
Since swiftlint 0.43.0 the expluded paths are not working because we use an external temp file and on 0.43.0 it started being relative to the file.
So add `${PWD}` to the paths so they exclude the folders where the `swiflint` command is called.

Also exclude `example-app`

Breaking because it won't work on 0.42.0 and older.